### PR TITLE
feat: improve NixOS compatibility with portable shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Claude Code PROJECT_INDEX Installer

--- a/scripts/find_python.sh
+++ b/scripts/find_python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Python finder for PROJECT_INDEX
 # Finds the newest Python 3.8+ version available
 

--- a/scripts/run_python.sh
+++ b/scripts/run_python.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Python runner that uses the saved Python command from installation
 
 INSTALL_DIR="$HOME/.claude-code-project-index"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Claude Code PROJECT_INDEX Uninstaller


### PR DESCRIPTION
## Summary

This PR improves cross-platform compatibility, particularly for NixOS users, by using portable shebang declarations in shell scripts.

### Changes Made

- Changed `#!/bin/bash` to `#!/usr/bin/env bash` in all shell scripts:
  - `install.sh`
  - `scripts/find_python.sh`
  - `scripts/run_python.sh` 
  - `uninstall.sh`

### Why This Matters

On NixOS and some other distributions, bash is not located at `/bin/bash` but rather in the Nix store or other locations. Using `#!/usr/bin/env bash` allows the system to find bash in the PATH, making the scripts work out of the box on these systems.

### Testing

- Scripts continue to work on traditional Linux distributions
- Now work correctly on NixOS without requiring user modifications
- No functional changes to script behavior

This is a small but important change that makes the project more accessible to users on alternative distributions.

### Related Issues

This addresses the common issue where PROJECT_INDEX installation fails on NixOS due to hardcoded bash paths.